### PR TITLE
Added scripts for building with Nix (or Cabal sandboxes)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /_site/
 /cabal.sandbox.config
 /dist/
+shell.nix

--- a/bin/build-with-cabal-sandbox
+++ b/bin/build-with-cabal-sandbox
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -eu
+
+cabal sandbox init
+cabal install --only-dependencies

--- a/bin/build-with-nix
+++ b/bin/build-with-nix
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -eu
+
+cabal2nix --shell . >shell.nix
+nix-shell --run 'cabal configure && cabal build'

--- a/talks.cabal
+++ b/talks.cabal
@@ -2,11 +2,13 @@ name:               talks
 version:            0.1.0.0
 build-type:         Simple
 cabal-version:      >= 1.10
+license:            PublicDomain
+license-file:       LICENSE
 
 executable site
   main-is:          site.hs
   build-depends:    base == 4.*
-                  , hakyll == 4.6.*
+                  , hakyll == 4.7.*
                   , pandoc
   ghc-options:      -threaded
   default-language: Haskell2010


### PR DESCRIPTION
When building with cabal sandbox this takes 40 minutes (the first time) and it takes more than 0.5 a gig of disk space.

I've had some success using Nix on Mac [[https://nixos.org/wiki/Nix_on_OS_X#Using_the_Development_Branch][by following this guide]]. Note that I'm on "OS X Yosemite" Version 10.10.3. Don't forget that you need to install cabal2nix in your user environment (this does take a while, no binary substitution was found):

    $ nix-env --install cabal2nix

With Nix, running bin/build-with-nix is super quick. All packages will be shared with other Hakyll based projects that you may be using. So hopefully you'll like it.